### PR TITLE
ubuntu-14.04-base: added iostat package so the iostat dump works

### DIFF
--- a/dockerfiles/ubuntu-14.04-base/Dockerfile
+++ b/dockerfiles/ubuntu-14.04-base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
         git-core \
         diffstat \
         unzip \
+        sysstat \
         texinfo \
         gcc-multilib \
         build-essential \


### PR DESCRIPTION
Added the iostat package to the ubuntu base container so that the
host_00_iostat file from testimage_dump_host in poky has information in it.